### PR TITLE
use throttle to slow down rendering long threads

### DIFF
--- a/app/html/comments.js
+++ b/app/html/comments.js
@@ -1,5 +1,5 @@
 const nest = require('depnest')
-const { h, Array: MutantArray, Value, map, computed, when, resolve } = require('mutant')
+const { h, Array: MutantArray, Value, map, computed, when, resolve, throttle } = require('mutant')
 const get = require('lodash/get')
 
 exports.gives = nest('app.html.comments')
@@ -24,7 +24,8 @@ exports.create = (api) => {
     const { messages, channel, lastId: branch } = api.feed.obs.thread(root)
 
     // TODO - move this up into Patchcore
-    const messagesTree = computed(messages, msgs => {
+    var debouncer = null
+    const messagesTree = computed(throttle(messages, 200), msgs => {
       return msgs
         .filter(msg => forkOf(msg) === undefined)
         .map(threadMsg => { 
@@ -138,3 +139,5 @@ exports.create = (api) => {
 function forkOf (msg) {
   return get(msg, 'value.content.fork')
 }
+
+


### PR DESCRIPTION
Really long threads would lock up - looking at the code I guessed it immediately:
the thread observable was updating for each message, and this also causes it to redraw all the threads (rendering them, then diffing them with all already rendered messages)

This means it rerenders the whole thread (so far) for every message - that means it takes O(N*N/2) time (note: like the area of a triangle base/2*height), instead of O(N) time...

For short threads, this difference isn't very big, 10 vs 50 (5x), but for bigger threads it becomes more significant 100 vs 5000 (50x) if it would have taken a second to render 100 items, then now it takes 50 seconds.