### PR TITLE
Bug disable post button

### DIFF
--- a/message/html/subject.js
+++ b/message/html/subject.js
@@ -23,10 +23,10 @@ exports.create = function (api) {
 
       api.sbot.async.get(msg, (err, value) => {
         if (err) throw err
-
+        
         subject.set(getMsgSubject({
           key: msg,
-          value: api.message.sync.unbox(value)
+          value: typeof value === "string" ? api.message.sync.unbox(value) : value
         }))
       })
 

--- a/styles/button.mcss
+++ b/styles/button.mcss
@@ -63,5 +63,9 @@ Button {
     border-right: none
     border-bottom: none
   }
+
+  -disabled {
+    cursor: default
+  }
 }
 


### PR DESCRIPTION
The implementation was easy but I lost sometime with a bug in my own feed due to an entry that I posted in the past as a "private" entry without boxing it. To make sure that we don't try to unbox non-boxed content, I have added a check in `message.html.subject`. As more developers start trying to implement ssb stuff without full knowledge of the API, we're bound to encounter more and more broken messages like that one I posted in the past...