### PR TITLE
catch missing ticktack plugin

### DIFF
--- a/app/html/header.js
+++ b/app/html/header.js
@@ -4,6 +4,9 @@ const path = require('path')
 const { remote } = require('electron')
 
 exports.gives = nest('app.html.header')
+exports.needs = nest({
+  'app.obs.pluginsOk': 'first'
+})
 
 const SETTINGS_PAGES = [
   'settings',
@@ -41,9 +44,17 @@ exports.create = (api) => {
           src: when(isSettings, assetPath('settings_on.png'), assetPath('settings.png')),
           'ev-click': () => push({page: 'settings'})
         }),
-        h('i.fa', {
-          className: when(isNotifications, 'fa-bell', 'fa-bell-o'),
-          'ev-click': () => push({page: 'statsShow'})
+        computed(api.app.obs.pluginsOk(), ok => {
+          return h('i.fa', {
+            classList: [
+              when(isNotifications, 'fa-bell', 'fa-bell-o'),
+              when(!ok, '-disabled')
+            ],
+            'ev-click': () => {
+              if (!ok) return
+              push({page: 'statsShow'})
+            }
+          })
         })
       ])
     ])

--- a/app/html/header.mcss
+++ b/app/html/header.mcss
@@ -38,6 +38,10 @@ Header {
 
     i { font-size: 1.4rem }
     i.fa-bell-o { color: #7da9ea }
+    i.-disabled { 
+      filter: opacity(.4)
+      cursor: not-allowed
+    }
 
     (a) {
       color: #222

--- a/app/html/sideNav/sideNav.mcss
+++ b/app/html/sideNav/sideNav.mcss
@@ -54,6 +54,7 @@ Option {
     opacity: .5
     :hover {
       cursor: not-allowed
+      background: initial
     }
   }
 

--- a/app/obs/pluginsOk.js
+++ b/app/obs/pluginsOk.js
@@ -1,5 +1,5 @@
 const nest = require('depnest')
-const { h, onceTrue, Value } = require('mutant')
+const { onceTrue, Value } = require('mutant')
 
 exports.gives = nest('app.obs.pluginsOk')
 
@@ -8,10 +8,11 @@ exports.needs = nest({
 })
 
 exports.create = (api) => {
+  // TODO - differentiate and enable / disable based on channel || ticktack plugin missing
   var ok = Value()
 
   return nest('app.obs.pluginsOk', function pluginsOk () {
-    if (ok() == undefined) checkForTrouble()
+    if (ok() === null) checkForTrouble()
 
     return ok
   })
@@ -20,10 +21,12 @@ exports.create = (api) => {
     onceTrue(
       api.sbot.obs.connection,
       sbot => {
-        if (!sbot.channel) ok.set(false) // TODO could build a list of missing plugins + effects
+        if (!sbot.channel) console.log('> channel plugin missing!')
+        if (!sbot.tickack) console.log('> ticktack plugin missing!')
+
+        if (!sbot.channel || !sbot.ticktack) ok.set(false) // TODO could build a list of missing plugins + effects
         else ok.set(true)
       }
     )
   }
 }
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ticktack",
-  "version": "0.3.3",
+  "version": "0.4.0-prerelease-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
at the moment if someone opens Ticktack and Patchwork is running they get a warning and are protected from the channel plugin not being present.

I missed protecting against the ticktack (stats) plugin being missing though!
This closes the whole stats page down. I think there could be more work done on differentiating what exactly is missing and telling the user which functionality will be missing from ticktack.

Need to get this in, so merging.
happy to discuss more cc @soapdog 